### PR TITLE
Support exact object type

### DIFF
--- a/src/converters/convert_flow_type.ts
+++ b/src/converters/convert_flow_type.ts
@@ -253,6 +253,7 @@ export function convertFlowType(path: NodePath<FlowType>): TSType {
         const objectTypeNode = path.node as ObjectTypeAnnotation;
         if (objectTypeNode.exact) {
             warnOnlyOnce('Exact object type annotation in Flow is ignored. In TypeScript, it\'s always regarded as exact type');
+            objectTypeNode.exact = false
         }
 
         if (objectTypeNode.properties && objectTypeNode.properties.length > 0) {

--- a/src/converters/convert_type_annotation.ts
+++ b/src/converters/convert_type_annotation.ts
@@ -1,11 +1,26 @@
 import {NodePath} from '@babel/traverse';
 import {
     tsTypeAnnotation,
+    tsTypeAliasDeclaration,
     TSTypeAnnotation,
-    TypeAnnotation
+    TSTypeAliasDeclaration,
+    TypeAnnotation,
+    TypeAlias,
 } from '@babel/types';
 import {convertFlowType} from './convert_flow_type';
+import {convertTypeParameterDeclaration} from './convert_type_parameter_declaration';
 
 export function convertTypeAnnotation(path: NodePath<TypeAnnotation>): TSTypeAnnotation {
     return tsTypeAnnotation(convertFlowType(path.get('typeAnnotation')));
+}
+export function convertTypeAlias(path: NodePath<TypeAlias>): TSTypeAliasDeclaration {
+    const typeParameters = path.get('typeParameters')
+    const right = path.get('right')
+    return tsTypeAliasDeclaration(
+        path.node.id,
+        typeParameters.isTypeParameterDeclaration()
+            ? convertTypeParameterDeclaration(typeParameters)
+            : null,
+        convertFlowType(right)
+    );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 import {buildPlugin} from './plugin';
 import {ImportDeclaration} from './visitors/import_declaration';
 import {OpaqueType} from './visitors/opaque_type';
-import {TypeAnnotation} from './visitors/type_annotation';
+import {TypeAnnotation, TypeAlias} from './visitors/type_annotation';
 import {TypeCastExpression} from './visitors/type_cast_expression';
 import {TypeParameterDeclaration} from './visitors/type_parameter_declaration';
 
 export = buildPlugin([
     TypeAnnotation,
+    TypeAlias,
     TypeParameterDeclaration,
     ImportDeclaration,
     TypeCastExpression,

--- a/src/visitors/type_annotation.ts
+++ b/src/visitors/type_annotation.ts
@@ -1,7 +1,10 @@
-import {TypeAnnotation} from '@babel/types';
+import {TypeAnnotation, TypeAlias} from '@babel/types';
 import {NodePath} from '@babel/traverse';
-import {convertTypeAnnotation} from '../converters/convert_type_annotation';
+import {convertTypeAnnotation, convertTypeAlias} from '../converters/convert_type_annotation';
 
 export function TypeAnnotation(path: NodePath<TypeAnnotation>) {
     path.replaceWith(convertTypeAnnotation(path));
+}
+export function TypeAlias(path: NodePath<TypeAlias>) {
+    path.replaceWith(convertTypeAlias(path))
 }

--- a/test/visitors/type_annotation.test.ts
+++ b/test/visitors/type_annotation.test.ts
@@ -1,9 +1,9 @@
 import * as pluginTester from 'babel-plugin-tester';
 import {buildPlugin} from '../../src/plugin';
-import {TypeAnnotation} from '../../src/visitors/type_annotation';
+import {TypeAnnotation, TypeAlias} from '../../src/visitors/type_annotation';
 
 pluginTester({
-    plugin: buildPlugin([TypeAnnotation]),
+    plugin: buildPlugin([TypeAnnotation, TypeAlias]),
     tests: [{
         title: 'Any type',
         code: `let a: any;`,
@@ -72,6 +72,12 @@ pluginTester({
         title: 'Object type: exact=true',
         code: `let a: {| a: T |};`,
         output: `let a: {
+  a: T;
+};`
+    }, {
+        title: 'Object type alias: exact=true',
+        code: `type a = {| a: T |};`,
+        output: `type a = {
   a: T;
 };`
     }, {

--- a/test/visitors/type_annotation.test.ts
+++ b/test/visitors/type_annotation.test.ts
@@ -69,6 +69,12 @@ pluginTester({
         code: `let a: $ElementType<T, k>;`,
         output: `let a: T[k];`
     }, {
+        title: 'Object type: exact=true',
+        code: `let a: {| a: T |};`,
+        output: `let a: {
+  a: T;
+};`
+    }, {
         title: 'Intersection type',
         code: `let a: {x: number} & {y: string};`,
         output: `let a: {


### PR DESCRIPTION
I added to support exact object type (`{| ... |}`).

Actual:

```js
let a: {| a: T |};
```

Exepcted:

```ts
let a: {
  a: T;
};
```
