### PR TITLE
Add support for function type annotation

### DIFF
--- a/src/converters/convert_flow_type.ts
+++ b/src/converters/convert_flow_type.ts
@@ -3,6 +3,8 @@ import {
     booleanLiteral,
     FlowType,
     FunctionDeclaration,
+    FunctionTypeAnnotation,
+    FunctionTypeParam,
     GenericTypeAnnotation,
     Identifier,
     identifier,
@@ -44,6 +46,7 @@ import {
     tsAnyKeyword,
     tsArrayType,
     tsBooleanKeyword,
+    tsFunctionType,
     tsIndexedAccessType,
     tsIndexSignature,
     tsIntersectionType,
@@ -333,7 +336,20 @@ export function convertFlowType(path: NodePath<FlowType>): TSType {
     }
 
     if (isNodePath(isFunctionTypeAnnotation, path)) {
-        throw new UnsupportedError('NIY');
+        const nodePath = path as NodePath<FunctionTypeAnnotation>;
+        const identifiers = path.node.params.map((p, i) => {
+            const name = (p.name && p.name.name) || `x${i}`;
+            const ftParam = nodePath.get(`params.${i}`) as NodePath<FunctionTypeParam>;
+            const typeAnn = ftParam.get('typeAnnotation') as NodePath<FlowType>;
+
+            const iden = identifier(name);
+            iden.typeAnnotation = tsTypeAnnotation(convertFlowType(typeAnn));
+            return iden;
+        });
+        const returnType = tsTypeAnnotation(convertFlowType(nodePath.get('returnType')));
+        const tsFT = tsFunctionType(null, returnType);
+        tsFT.parameters = identifiers;
+        return tsFT;
     }
 
     if (isNodePath(isTupleTypeAnnotation, path)) {

--- a/test/visitors/type_annotation.test.ts
+++ b/test/visitors/type_annotation.test.ts
@@ -153,5 +153,10 @@ pluginTester({
         title: 'Void literal',
         code: `let a: void;`,
         output: `let a: void;`,
+    }, {
+        title: 'Function type annotation',
+        code: `const f: X<T> => string = (x) => '';`,
+        output: `const f: (x0: X<T>) => string = x => '';`,
+
     }]
 });


### PR DESCRIPTION
### Example
```javascript
// @flow
const f1: () => string = () => '';
const f2: (string, number) => string = (s, n) => s[n];
```

gets converted to

```typescript
const f1: () => string = () => '';
const f2: (x0: string, x1: number) => string = (s, n) => s[n];
```