### PR TITLE
Add Object Rest Spread syntax support

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -10,6 +10,7 @@ export function buildPlugin(visitors: Function[]) {
         manipulateOptions(_opts: any, parserOpts: any) {
             parserOpts.plugins.push('flow');
             parserOpts.plugins.push('jsx');
+            parserOpts.plugins.push('objectRestSpread');
         }
     });
 }


### PR DESCRIPTION
Added the object-rest-spread syntax plugin.
No changes to the conversion logic as TypeScript accepts it as is.

e.g.
```javascript
{
    ...state,
    counter: counter + 1,
}
```