### PR TITLE
Remove class constructor return type

### DIFF
--- a/src/converters/convert_class_constructor.ts
+++ b/src/converters/convert_class_constructor.ts
@@ -1,0 +1,16 @@
+import {NodePath} from '@babel/traverse';
+import {
+    classMethod,
+    ClassMethod,
+} from '@babel/types';
+
+export function convertClassConstructor(path: NodePath<ClassMethod>): ClassMethod {
+    const node = path.node;
+
+    if (node.returnType === null) return node;
+
+    const ret = classMethod(node.kind, node.key, node.params, node.body, node.computed, node.static);
+    ret.returnType = null;
+
+    return ret;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {OpaqueType} from './visitors/opaque_type';
 import {TypeAnnotation, TypeAlias} from './visitors/type_annotation';
 import {TypeCastExpression} from './visitors/type_cast_expression';
 import {TypeParameterDeclaration} from './visitors/type_parameter_declaration';
+import {ClassMethod} from './visitors/class_method';
 
 export = buildPlugin([
     TypeAnnotation,
@@ -12,5 +13,6 @@ export = buildPlugin([
     ImportDeclaration,
     ImportSpecifier,
     TypeCastExpression,
-    OpaqueType
+    OpaqueType,
+    ClassMethod
 ]);

--- a/src/visitors/class_method.ts
+++ b/src/visitors/class_method.ts
@@ -1,0 +1,9 @@
+import {ClassMethod} from '@babel/types';
+import {NodePath} from '@babel/traverse';
+import {convertClassConstructor} from '../converters/convert_class_constructor';
+
+export function ClassMethod(path: NodePath<ClassMethod>) {
+    if (path.node.kind === 'constructor') {
+        path.replaceWith(convertClassConstructor(path));
+    }
+}

--- a/test/visitors/class_method.test.ts
+++ b/test/visitors/class_method.test.ts
@@ -1,0 +1,18 @@
+import * as pluginTester from 'babel-plugin-tester';
+import {buildPlugin} from '../../src/plugin';
+import {ClassMethod} from '../../src/visitors/class_method';
+
+pluginTester({
+    plugin: buildPlugin([ClassMethod]),
+    tests: [{
+        title: 'Class constructors: No return type annotation',
+        code: `class C {
+  constructor(): void {
+  }
+}`,
+        output: `class C {
+  constructor() {}
+
+}`,
+    }]
+});


### PR DESCRIPTION
TypeScript does not allow return types to be specified for class constructors (Flow does).

This PR explicitly sets the return type to `null` for class constructors.