### PR TITLE
Pass in identifiers as parametrs

### DIFF
--- a/src/converters/convert_flow_type.ts
+++ b/src/converters/convert_flow_type.ts
@@ -363,9 +363,7 @@ export function convertFlowType(path: NodePath<FlowType>): TSType {
             return iden;
         });
         const returnType = tsTypeAnnotation(convertFlowType(nodePath.get('returnType')));
-        const tsFT = tsFunctionType(null, returnType);
-        tsFT.parameters = identifiers;
-        return tsFT;
+        return tsFunctionType(null, identifiers, returnType);
     }
 
     if (isNodePath(isTupleTypeAnnotation, path)) {


### PR DESCRIPTION
Due to https://github.com/babel/babel/commit/a35e5a314ab533828d0988a2da824edb04fc8d3c, this plugin errors when a file contains a function type annotation:

```
TypeError: Property parameters expected type of array but got object
    at validate (node_modules/@babel/types/lib/definitions/utils.js:161:13)
    at Object.validate (node_modules/@babel/types/lib/definitions/utils.js:172:7)
    at validate (node_modules/@babel/types/lib/validators/validate.js:17:9)
    at builder (node_modules/@babel/types/lib/builders/builder.js:46:27)
    at Object.TSFunctionType (node_modules/@babel/types/lib/builders/generated/index.js:975:31)
    at convertFlowType (node_modules/babel-plugin-flow-to-typescript/dist/converters/convert_flow_type.js:259:26)
    at Object.convertFlowType (node_modules/babel-plugin-flow-to-typescript/dist/converters/convert_flow_type.js:184:38)
    at Object.convertTypeAlias (node_modules/babel-plugin-flow-to-typescript/dist/converters/convert_type_annotation.js:15:37)
    at PluginPass.TypeAlias (node_modules/babel-plugin-flow-to-typescript/dist/visitors/type_annotation.js:10:48)
    at newFn (node_modules/@babel/core/node_modules/@babel/traverse/lib/visitors.js:193:21)
```

This update passes in the newly-added `parameters`.