### PR TITLE
feat: modify to convert flow Object type to any

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ babel --plugins babel-plugin-flow-to-typescript ${SRC_FLOW_FILE} -o ${DEST_TS_
 | ---------- | --------------------- | --------------------------------- | ----------------------------------------------- |
 | ✅         | Maybe type            | `let a:?number`                   | `let a: number \| null \| undefined`            |
 | ✅         | Void type             | `void`                            | `void`                                          |
-| ✅         | Object type           | `Object`                          | `object`                                        |
+| ✅         | Object type           | `Object`                          | `any`                                           |
 | ✅         | Mixed type            | `mixed`                           | `unknown`                                       |
 | ✅         | Function type         | `(A, B) => C`                     | `(x1: A, x2: B) => C`                           |
 | ✅         | Exact type            | `{\| a: A \|}`                    | `{ a: A }`                                      |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-flow-to-typescript",
-  "version": "0.5.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dist/*",
     "README.md"
   ],
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "prepare": "npm run build",
     "test": "jest",

--- a/src/converters/convert_flow_type.ts
+++ b/src/converters/convert_flow_type.ts
@@ -46,7 +46,6 @@ import {
   tsNeverKeyword,
   tsNullKeyword,
   tsNumberKeyword,
-  tsObjectKeyword,
   tsParenthesizedType,
   tsStringKeyword,
   tsThisType,
@@ -196,7 +195,7 @@ export function convertFlowType(node: FlowType): TSType {
     } else if (isIdentifier(id) && id.name === '$FlowFixMe') {
       return tsTypeReference(identifier('any'), tsTypeParameters);
     } else if (isIdentifier(id) && id.name === 'Object') {
-      return tsObjectKeyword();
+      return tsAnyKeyword();
     } else if (isQualifiedTypeIdentifier(id) || isIdentifier(id)) {
       return tsTypeReference(
         convertFlowIdentifier(id),

--- a/test/visitors/program.test.ts
+++ b/test/visitors/program.test.ts
@@ -64,7 +64,7 @@ type B = Class<{
 type C = Class<A>;
 `,
       output: `type Class<T> = new (...args: any) => T;
-type A = string | Class<React.Component<any, any>> | object;
+type A = string | Class<React.Component<any, any>> | any;
 type B = Class<{
   readonly scope: (a: TagsType) => void;
 }>;

--- a/test/visitors/type_annotation.test.ts
+++ b/test/visitors/type_annotation.test.ts
@@ -334,7 +334,7 @@ type B = A.A.A;`,
     {
       title: 'Object type',
       code: `let a: Object;`,
-      output: `let a: object;`,
+      output: `let a: any;`,
     },
 
     {


### PR DESCRIPTION
flowtype official doc says 'Object is an alias to any and will be deprecated' in here
https://flow.org/en/docs/types/objects/#toc-object-type
And TypeScript `object` type is not same to `any`, TypeScript doc says 'object is a type that represents the non-primitive type, i.e. anything that is not number, string, boolean, bigint, symbol, null, or undefined.'
https://www.typescriptlang.org/docs/handbook/basic-types.html#object

So I think converting `Object` into `any` is better.